### PR TITLE
Add new format modifiers for windows number

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ With this option you can customize the look of tabs. Below all the available ite
 - `%N`: the tab number on each tab
 - `%w`: the number of windows opened into the tab, but only on the active tab
 - `%W`: the number of windows opened into the tab, on each tab
+- `%u`: same as %w, but using unicode characters
+- `%U`: same as %W, but using unicode characters
 - `%m`: the modified flag
 
 Default: `" %f%m "`

--- a/doc/taboo.txt
+++ b/doc/taboo.txt
@@ -76,6 +76,8 @@ available items:
     `%N` -> the tab number on each tab
     `%w` -> the number of windows opened into the tab, but only on the active tab
     `%W` -> the number of windows opened into the tab, on each tab
+    `%u` -> same as %w, but using unicode characters
+    `%U` -> same as %W, but using unicode characters
     `%m` -> the modified flag
 
 Default: " %f%m "

--- a/plugin/taboo.vim
+++ b/plugin/taboo.vim
@@ -110,6 +110,8 @@ fu s:expand(tabnr, fmt)
     let out = substitute(out, '\C%N', s:tabnum(a:tabnr, 1), "")
     let out = substitute(out, '\C%w', s:wincount(a:tabnr, 0), "")
     let out = substitute(out, '\C%W', s:wincount(a:tabnr, 1), "")
+    let out = substitute(out, '\C%u', s:wincountUnicode(a:tabnr, 0), "")
+    let out = substitute(out, '\C%U', s:wincountUnicode(a:tabnr, 1), "")
     let out = substitute(out, '\C%m', s:modflag(a:tabnr), "")
     let out = substitute(out, '\C%l', s:tabname(a:tabnr), "")
     return out
@@ -132,6 +134,25 @@ fu s:wincount(tabnr, ubiquitous)
         return windows
     endif
     return a:tabnr == tabpagenr() ? windows : ''
+endfu
+
+" Adapted from Vim-CtrlSpace (https://github.com/szw/vim-ctrlspace)
+fu s:wincountUnicode(tabnr, ubiquitous)
+    let buffers_number = tabpagewinnr(a:tabnr, '$')
+    let number_to_show = ""
+
+    let small_numbers = ["⁰", "¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹"]
+    let number_str    = string(buffers_number)
+
+    for i in range(0, len(number_str) - 1)
+        let number_to_show .= small_numbers[str2nr(number_str[i])]
+    endfor
+
+    if a:ubiquitous
+        return number_to_show
+    endif
+
+    return a:tabnr == tabpagenr() ? number_to_show : ''
 endfu
 
 fu s:modflag(tabnr)


### PR DESCRIPTION
Added new format modifiers %u and %U that act like %w and %W but display the
number using unicode characters, making the number less visible.

This may be preferable since you may want to know how many splits you have in a tab window but now confuse that number with the tab number itself. I also think it looks pretty cool.
Here's a screenshot showing result 
![schermata 2015-05-01 alle 14 53 28](https://cloud.githubusercontent.com/assets/85527/7430372/9f41950a-f012-11e4-8f5f-d9de6fa0bdbe.png)
