### PR TITLE
list out of index error

### DIFF
--- a/plugin/taboo.vim
+++ b/plugin/taboo.vim
@@ -127,7 +127,7 @@ fu s:tabpwd(tabnr, last_component)
   let tabcwd = s:gettabvar(a:tabnr, "taboo_tab_wd")
 
   if a:last_component
-    let tabcwd = split(tabcwd, "/")[-1]
+    let tabcwd = get(split(tabcwd, "/"), -1, "")
   endif
 
   return tabcwd


### PR DESCRIPTION
I have this autocmd:
autocmd BufEnter *.txt if &ft == 'help'| wincmd T | endif

sometimes taboo will fail at this line.
I don't know if returning "" is correct, but it works for me.