### PR TITLE
Add "default" to highlight links

### DIFF
--- a/plugin/taboo.vim
+++ b/plugin/taboo.vim
@@ -327,8 +327,8 @@ augroup END
 " Highlight Groups
 " =============================================================================
 " Link new highlight groups to reasonable/expected defaults
-highlight link TabModified TabLine
-highlight link TabModifiedSelected TabLineSel
+highlight default link TabModified TabLine
+highlight default link TabModifiedSelected TabLineSel
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
The new highlight groups TabModified and TabModifiedSelected are linked
to TabLine and TabLineSel. Adding "default" allows these links to be
easily overridden in a .vimrc, see :h hi-default