### PR TITLE
Don't return a tab name modified flag if we're not in control of the tabline.

### DIFF
--- a/plugin/taboo.vim
+++ b/plugin/taboo.vim
@@ -172,6 +172,9 @@ fu s:wincountUnicode(tabnr, ubiquitous)
 endfu
 
 fu s:modflag(tabnr)
+    if !g:taboo_tabline
+        return ""
+    endif
     for buf in tabpagebuflist(a:tabnr)
         if getbufvar(buf, "&mod")
             if a:tabnr == tabpagenr()


### PR DESCRIPTION
Solves this issues https://github.com/gcmt/taboo.vim/issues/22 by removing any modifies from the tab name if it's not being drawn by Taboo