### PR TITLE
Adds %x for close button per tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ With this option you can customize the look of tabs. Below all the available ite
 - `%m`: the modified flag
 - `%p`: the tab current working directory
 - `%P`: the last component of the tab current working directory
+- `%x`: close tab button, see `g:taboo_close_tab_label`
 
 Default: `" %f%m "`
 
@@ -63,6 +64,12 @@ Default: `"*"`
 Turn off this option and Taboo won't generate the tabline. This may be useful if you want to do it yourself with the help of the functions `TabooTabTitle(..)` or `TabooTabName(..)`.
 
 Default: `1`
+
+**g:taboo\_close\_tab\_label**
+
+This option controls how the close button looks like.
+
+Default: `"x"`
 
 ### Public interface
 

--- a/doc/taboo.txt
+++ b/doc/taboo.txt
@@ -80,6 +80,7 @@ available items:
     `%u` -> same as %w, but using unicode characters
     `%U` -> same as %W, but using unicode characters
     `%m` -> the modified flag
+    `%x` -> close tab button, see |'taboo_close_tab_label'|
 
 Default: " %f%m "
 
@@ -121,6 +122,13 @@ This position is fixed. When the value is an empty string nothing will be
 displayed.
 
 Default: ""
+
+------------------------------------------------------------------------------
+                                                    *'taboo_close_tab_label'*
+
+This option controls how the close button looks like.
+
+Default: "x"
 
 ------------------------------------------------------------------------------
                                                    *'taboo_unnamed_tab_label'*

--- a/plugin/taboo.vim
+++ b/plugin/taboo.vim
@@ -40,6 +40,9 @@ let g:taboo_modified_tab_flag =
 let g:taboo_close_tabs_label =
     \ get(g:, "taboo_close_tabs_label", "")
 
+let g:taboo_close_tab_label =
+    \ get(g:, "taboo_close_tab_label", "x")
+
 let g:taboo_unnamed_tab_label =
     \ get(g:, "taboo_unnamed_tab_label", "[no name]")
 
@@ -116,6 +119,7 @@ fu s:expand(tabnr, fmt)
     let out = substitute(out, '\C%l', s:tabname(a:tabnr), "")
     let out = substitute(out, '\C%p', s:tabpwd(a:tabnr, 0), "")
     let out = substitute(out, '\C%P', s:tabpwd(a:tabnr, 1), "")
+    let out = substitute(out, '\C%x', s:tabclose(a:tabnr), "")
     return out
 endfu
 
@@ -186,6 +190,10 @@ fu s:modflag(tabnr)
         endif
     endfor
     return ""
+endfu
+
+fu s:tabclose(tabnr)
+  return '%' . a:tabnr . 'X' . g:taboo_close_tab_label . '%X'
 endfu
 
 fu s:bufname(tabnr)


### PR DESCRIPTION
Now there is a way to have individual close buttons for each tab!

Example:
```vim
" brackets around %x  also serve as extra padding to prevent accidental button click
let g:taboo_tab_format = " %N %f%m [%x] "
let g:taboo_renamed_tab_format = " %N %l%m [%x] "
let g:taboo_close_tab_label = "x"
```
![close](https://user-images.githubusercontent.com/717109/51320847-c6c1f900-1a69-11e9-87ca-7160a0918441.png)