### PR TITLE
Make the current, and the next to the current, tabs always visible

### DIFF
--- a/plugin/taboo.vim
+++ b/plugin/taboo.vim
@@ -75,9 +75,6 @@ fu TabooTabline()
         let title = s:expand(i, fmt)
         let width = strwidth(substitute(title, '%#[^#]*#\|%\d\{-}T', '', 'g'))
         let titles += [[prefix . title, width]]
-        if i == tabpagenr('$')
-            break
-        endif
         let current_width += width
         if (current_width > max_width)
             if i <= tabpagenr() + 1


### PR DESCRIPTION
Currently, if the tabline becomes too long, the current tab gets hidden. This PR makes sure the current tab is always visible.